### PR TITLE
Д/з: Кэширование + Команды

### DIFF
--- a/app/Console/Commands/WarmupCache.php
+++ b/app/Console/Commands/WarmupCache.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Cache\CacheService;
+use App\Services\User\UserService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class WarmupCache extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cache:warmup';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Warmup app cache';
+
+    /**
+     * @var UserService
+     */
+    private $userService;
+
+    /**
+     * @var CacheService
+     */
+    private $cacheService;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  UserService  $userService
+     * @param  CacheService  $cacheService
+     */
+    public function __construct(UserService $userService, CacheService $cacheService)
+    {
+        parent::__construct();
+        $this->userService = $userService;
+        $this->cacheService = $cacheService;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Cache::flush();
+        $users = $this->userService->all();
+        if (!$users->count()) {
+            $this->error('No users found');
+            return;
+        }
+        foreach ($users as $user) {
+            $this->cacheService->warmupCacheByUser($user);
+            $this->line('Warmed up cache for '.$user->name);
+        }
+    }
+}

--- a/app/Http/Controllers/Backend/LocationController.php
+++ b/app/Http/Controllers/Backend/LocationController.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Services\Location\LocationService;
 use App\Services\User\UserService;
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use App\Policies\Abilities;
 use Illuminate\Support\Facades\Auth;
@@ -42,14 +43,18 @@ class LocationController extends Controller
     /**
      * Display a listing of the resource.
      *
+     * @param  Request  $request
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function index()
+    public function index(Request $request)
     {
         $this->authorize(Abilities::VIEW_ANY, Location::class);
+        $filters = [
+            'page' => $request->get('page'),
+        ];
         return view('backend.pages.location.index', [
-            'locations' => $this->locationService->getByUser(Auth::user()),
+            'locations' => $this->locationService->getByUserCached(Auth::user(), $filters),
         ]);
     }
 

--- a/app/Http/Controllers/Backend/WorkoutController.php
+++ b/app/Http/Controllers/Backend/WorkoutController.php
@@ -10,6 +10,7 @@ use App\Services\Location\LocationService;
 use App\Services\Workout\WorkoutService;
 use App\Services\User\UserService;
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use App\Policies\Abilities;
 use Illuminate\Support\Facades\Auth;
@@ -57,11 +58,14 @@ class WorkoutController extends Controller
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function index()
+    public function index(Request $request)
     {
         $this->authorize(Abilities::VIEW_ANY, Workout::class);
+        $filters = [
+            'page' => $request->get('page'),
+        ];
         return view('backend.pages.workout.index', [
-            'workouts' => $this->workoutService->getByUserCached(Auth::user()),
+            'workouts' => $this->workoutService->getByUserCached(Auth::user(), $filters),
         ]);
     }
 

--- a/app/Http/Controllers/Backend/WorkoutController.php
+++ b/app/Http/Controllers/Backend/WorkoutController.php
@@ -55,6 +55,7 @@ class WorkoutController extends Controller
     /**
      * Display a listing of the resource.
      *
+     * @param  Request  $request
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */

--- a/app/Http/Controllers/Backend/WorkoutController.php
+++ b/app/Http/Controllers/Backend/WorkoutController.php
@@ -61,7 +61,7 @@ class WorkoutController extends Controller
     {
         $this->authorize(Abilities::VIEW_ANY, Workout::class);
         return view('backend.pages.workout.index', [
-            'workouts' => $this->workoutService->getByUser(Auth::user()),
+            'workouts' => $this->workoutService->getByUserCached(Auth::user()),
         ]);
     }
 

--- a/app/Listeners/Cache/Location/ClearLocationCache.php
+++ b/app/Listeners/Cache/Location/ClearLocationCache.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Listeners\Cache\Location;
+
+use App\Services\Events\Models\Location\LocationEvent;
+use App\Services\Location\Repositories\LocationCachedRepository;
+
+class ClearLocationCache
+{
+
+    /** @var LocationCachedRepository */
+    private $locationCachedRepository;
+
+    /**
+     * ClearCountryCache constructor.
+     * @param  LocationCachedRepository  $locationCachedRepository
+     */
+    public function __construct(LocationCachedRepository $locationCachedRepository) {
+        $this->locationCachedRepository = $locationCachedRepository;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  LocationEvent  $event
+     * @return void
+     */
+    public function handle(LocationEvent $event)
+    {
+        $this->locationCachedRepository->clearSearchCache([
+            'user_id' => $event->getLocation()->user->id,
+        ]);
+    }
+}

--- a/app/Listeners/Cache/Location/ClearLocationCache.php
+++ b/app/Listeners/Cache/Location/ClearLocationCache.php
@@ -28,7 +28,7 @@ class ClearLocationCache
     public function handle(LocationEvent $event)
     {
         $this->locationCachedRepository->clearSearchCache([
-            'user_id' => $event->getLocation()->user->id,
+            'user_id' => $event->getLocation()->user_id,
         ]);
     }
 }

--- a/app/Listeners/Cache/Workout/ClearWorkoutCache.php
+++ b/app/Listeners/Cache/Workout/ClearWorkoutCache.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Listeners\Cache\Workout;
+
+use App\Services\Events\Models\Workout\WorkoutEvent;
+use App\Services\Workout\Repositories\WorkoutCachedRepository;
+
+class ClearWorkoutCache
+{
+
+    /** @var WorkoutCachedRepository */
+    private $workoutCachedRepository;
+
+    /**
+     * ClearCountryCache constructor.
+     * @param  WorkoutCachedRepository  $workoutCachedRepository
+     */
+    public function __construct(WorkoutCachedRepository $workoutCachedRepository) {
+        $this->workoutCachedRepository = $workoutCachedRepository;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  WorkoutEvent  $event
+     * @return void
+     */
+    public function handle(WorkoutEvent $event)
+    {
+        $this->workoutCachedRepository->clearSearchCache([
+            'user_id' => $event->getWorkout()->user->id,
+        ]);
+    }
+}

--- a/app/Listeners/Cache/Workout/ClearWorkoutCache.php
+++ b/app/Listeners/Cache/Workout/ClearWorkoutCache.php
@@ -28,7 +28,7 @@ class ClearWorkoutCache
     public function handle(WorkoutEvent $event)
     {
         $this->workoutCachedRepository->clearSearchCache([
-            'user_id' => $event->getWorkout()->user->id,
+            'user_id' => $event->getWorkout()->user_id,
         ]);
     }
 }

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Services\Events\Models\Location\LocationDeleted;
+use App\Services\Events\Models\Location\LocationSaved;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -22,6 +24,14 @@ class Location extends Model
         'name',
         'distance',
         'user_id',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $dispatchesEvents = [
+        'saved' => LocationSaved::class,
+        'deleted' => LocationDeleted::class,
     ];
 
     public function user()

--- a/app/Models/Workout.php
+++ b/app/Models/Workout.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Services\Events\Models\Workout\WorkoutDeleted;
+use App\Services\Events\Models\Workout\WorkoutSaved;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -25,6 +27,14 @@ class Workout extends Model
         'started_at',
         'duration',
         'location_id',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $dispatchesEvents = [
+        'saved' => WorkoutSaved::class,
+        'deleted' => WorkoutDeleted::class,
     ];
 
     public function user()

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Listeners\Cache\Workout\ClearWorkoutCache;
+use App\Services\Events\Models\Workout\WorkoutDeleted;
+use App\Services\Events\Models\Workout\WorkoutSaved;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -14,11 +17,17 @@ class EventServiceProvider extends ServiceProvider
      *
      * @var array
      */
-    protected $listen = [
-        Registered::class => [
+    protected $listen = array(
+        Registered::class => array(
             SendEmailVerificationNotification::class,
-        ],
-    ];
+        ),
+        WorkoutSaved::class => array(
+            ClearWorkoutCache::class,
+        ),
+        WorkoutDeleted::class => array(
+            ClearWorkoutCache::class,
+        ),
+    );
 
     /**
      * Register any events for your application.

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,7 +2,10 @@
 
 namespace App\Providers;
 
+use App\Listeners\Cache\Location\ClearLocationCache;
 use App\Listeners\Cache\Workout\ClearWorkoutCache;
+use App\Services\Events\Models\Location\LocationDeleted;
+use App\Services\Events\Models\Location\LocationSaved;
 use App\Services\Events\Models\Workout\WorkoutDeleted;
 use App\Services\Events\Models\Workout\WorkoutSaved;
 use Illuminate\Support\Facades\Event;
@@ -26,6 +29,12 @@ class EventServiceProvider extends ServiceProvider
         ),
         WorkoutDeleted::class => array(
             ClearWorkoutCache::class,
+        ),
+        LocationSaved::class => array(
+            ClearLocationCache::class,
+        ),
+        LocationDeleted::class => array(
+            ClearLocationCache::class,
         ),
     );
 

--- a/app/Services/Cache/CacheKeyService.php
+++ b/app/Services/Cache/CacheKeyService.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cache;
+
+use App\Services\Cache\Interfaces\CacheKeyServiceInterface;
+
+class CacheKeyService implements CacheKeyServiceInterface
+{
+
+    const CACHE_TTL = 600;
+
+    public static function getCacheKey(array $params = []): string
+    {
+        return 'cache.params:'.http_build_query($params);
+    }
+}

--- a/app/Services/Cache/CacheService.php
+++ b/app/Services/Cache/CacheService.php
@@ -4,15 +4,32 @@ declare(strict_types=1);
 
 namespace App\Services\Cache;
 
+use App\Models\User;
 use App\Services\Cache\Interfaces\CacheServiceInterface;
+use App\Services\Location\LocationService;
 
 class CacheService implements CacheServiceInterface
 {
 
     const CACHE_TTL = 600;
 
+    /**
+     * @var LocationService
+     */
+    private $locationService;
+
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
     public static function getCacheKey(array $params = []): string
     {
         return 'cache.params:'.http_build_query($params);
+    }
+
+    public function warmupCacheByUser(User $user): void
+    {
+        $this->locationService->warmupCacheByUser($user);
     }
 }

--- a/app/Services/Cache/CacheService.php
+++ b/app/Services/Cache/CacheService.php
@@ -7,6 +7,7 @@ namespace App\Services\Cache;
 use App\Models\User;
 use App\Services\Cache\Interfaces\CacheServiceInterface;
 use App\Services\Location\LocationService;
+use App\Services\Workout\WorkoutService;
 
 class CacheService implements CacheServiceInterface
 {
@@ -18,9 +19,15 @@ class CacheService implements CacheServiceInterface
      */
     private $locationService;
 
-    public function __construct(LocationService $locationService)
+    /**
+     * @var WorkoutService
+     */
+    private $workoutService;
+
+    public function __construct(LocationService $locationService, WorkoutService $workoutService)
     {
         $this->locationService = $locationService;
+        $this->workoutService = $workoutService;
     }
 
     public static function getCacheKey(array $params = []): string
@@ -31,5 +38,6 @@ class CacheService implements CacheServiceInterface
     public function warmupCacheByUser(User $user): void
     {
         $this->locationService->warmupCacheByUser($user);
+        $this->workoutService->warmupCacheByUser($user);
     }
 }

--- a/app/Services/Cache/CacheService.php
+++ b/app/Services/Cache/CacheService.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services\Cache;
 
-use App\Services\Cache\Interfaces\CacheKeyServiceInterface;
+use App\Services\Cache\Interfaces\CacheServiceInterface;
 
-class CacheKeyService implements CacheKeyServiceInterface
+class CacheService implements CacheServiceInterface
 {
 
     const CACHE_TTL = 600;

--- a/app/Services/Cache/CacheService.php
+++ b/app/Services/Cache/CacheService.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services\Cache;
 
+use App\Models\Location;
 use App\Models\User;
+use App\Models\Workout;
 use App\Services\Cache\Interfaces\CacheServiceInterface;
 use App\Services\Location\LocationService;
 use App\Services\Workout\WorkoutService;
@@ -13,6 +15,11 @@ class CacheService implements CacheServiceInterface
 {
 
     const CACHE_TTL = 600;
+
+    const USER_CACHE_TAG_PREFIXES = [
+        Location::class => 'Location.User:',
+        Workout::class => 'Workout.User:',
+    ];
 
     /**
      * @var LocationService
@@ -24,17 +31,44 @@ class CacheService implements CacheServiceInterface
      */
     private $workoutService;
 
+    /**
+     * CacheService constructor.
+     * @param  LocationService  $locationService
+     * @param  WorkoutService  $workoutService
+     */
     public function __construct(LocationService $locationService, WorkoutService $workoutService)
     {
         $this->locationService = $locationService;
         $this->workoutService = $workoutService;
     }
 
+    /**
+     * Get cache key for given params.
+     *
+     * @param  array  $params
+     * @return string
+     */
     public static function getCacheKey(array $params = []): string
     {
         return 'cache.params:'.http_build_query($params);
     }
 
+    /**
+     * Get cache user tag for given Model.
+     *
+     * @param  string  $modelClass
+     * @return string
+     */
+    public static function getCacheUserTagByModel(string $modelClass): string
+    {
+        return self::USER_CACHE_TAG_PREFIXES[$modelClass];
+    }
+
+    /**
+     * Warmup cache for user.
+     *
+     * @param  User  $user
+     */
     public function warmupCacheByUser(User $user): void
     {
         $this->locationService->warmupCacheByUser($user);

--- a/app/Services/Cache/Interfaces/CacheKeyServiceInterface.php
+++ b/app/Services/Cache/Interfaces/CacheKeyServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cache\Interfaces;
+
+interface CacheKeyServiceInterface
+{
+    public static function getCacheKey(array $params = []): string;
+}

--- a/app/Services/Cache/Interfaces/CacheServiceInterface.php
+++ b/app/Services/Cache/Interfaces/CacheServiceInterface.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services\Cache\Interfaces;
 
+use App\Models\User;
+
 interface CacheServiceInterface
 {
     public static function getCacheKey(array $params = []): string;
+
+    public function warmupCacheByUser(User $user): void;
 }

--- a/app/Services/Cache/Interfaces/CacheServiceInterface.php
+++ b/app/Services/Cache/Interfaces/CacheServiceInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Cache\Interfaces;
 
-interface CacheKeyServiceInterface
+interface CacheServiceInterface
 {
     public static function getCacheKey(array $params = []): string;
 }

--- a/app/Services/Cache/Interfaces/CacheServiceInterface.php
+++ b/app/Services/Cache/Interfaces/CacheServiceInterface.php
@@ -8,7 +8,26 @@ use App\Models\User;
 
 interface CacheServiceInterface
 {
+    /**
+     * Get cache key for given params.
+     *
+     * @param  array  $params
+     * @return string
+     */
     public static function getCacheKey(array $params = []): string;
 
+    /**
+     * Get cache user tag for given Model.
+     *
+     * @param  string  $modelClass
+     * @return string
+     */
+    public static function getCacheUserTagByModel(string $modelClass): string;
+
+    /**
+     * Warmup cache for user.
+     *
+     * @param  User  $user
+     */
     public function warmupCacheByUser(User $user): void;
 }

--- a/app/Services/Events/Models/Location/LocationDeleted.php
+++ b/app/Services/Events/Models/Location/LocationDeleted.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Services\Events\Models\Location;
+
+class LocationDeleted extends LocationEvent
+{
+}

--- a/app/Services/Events/Models/Location/LocationEvent.php
+++ b/app/Services/Events/Models/Location/LocationEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\Events\Models\Location;
+
+use App\Models\Location;
+
+abstract class LocationEvent
+{
+    /**
+     * @var Location
+     */
+    private $location;
+
+    public function __construct(Location $location)
+    {
+        $this->location = $location;
+    }
+
+    public function getLocation() {
+        return $this->location;
+    }
+}

--- a/app/Services/Events/Models/Location/LocationSaved.php
+++ b/app/Services/Events/Models/Location/LocationSaved.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Services\Events\Models\Location;
+
+class LocationSaved extends LocationEvent
+{
+}

--- a/app/Services/Events/Models/Workout/WorkoutDeleted.php
+++ b/app/Services/Events/Models/Workout/WorkoutDeleted.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Services\Events\Models\Workout;
+
+class WorkoutDeleted extends WorkoutEvent
+{
+}

--- a/app/Services/Events/Models/Workout/WorkoutEvent.php
+++ b/app/Services/Events/Models/Workout/WorkoutEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\Events\Models\Workout;
+
+use App\Models\Workout;
+
+abstract class WorkoutEvent
+{
+    /**
+     * @var Workout
+     */
+    private $workout;
+
+    public function __construct(Workout $workout)
+    {
+        $this->workout = $workout;
+    }
+
+    public function getWorkout() {
+        return $this->workout;
+    }
+}

--- a/app/Services/Events/Models/Workout/WorkoutSaved.php
+++ b/app/Services/Events/Models/Workout/WorkoutSaved.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Services\Events\Models\Workout;
+
+class WorkoutSaved extends WorkoutEvent
+{
+}

--- a/app/Services/Location/Interfaces/LocationCachedRepositoryInterface.php
+++ b/app/Services/Location/Interfaces/LocationCachedRepositoryInterface.php
@@ -25,4 +25,12 @@ interface LocationCachedRepositoryInterface
      */
     public function searchCached(array $conditions = [], array $filters = []);
 
+    /**
+     * Clear search cache.
+     *
+     * @param  array  $conditions
+     *   - user_id
+     */
+    public function clearSearchCache(array $conditions = ['user_id' => 0]);
+
 }

--- a/app/Services/Location/Interfaces/LocationCachedRepositoryInterface.php
+++ b/app/Services/Location/Interfaces/LocationCachedRepositoryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Location\Interfaces;
 
 use App\Models\Location;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 
 /**
@@ -32,5 +33,13 @@ interface LocationCachedRepositoryInterface
      *   - user_id
      */
     public function clearSearchCache(array $conditions = ['user_id' => 0]);
+
+    /**
+     * Warmup cache by user.
+     *
+     * @param  User  $user
+     * @return mixed
+     */
+    public function warmupCacheByUser(User $user);
 
 }

--- a/app/Services/Location/Interfaces/LocationCachedRepositoryInterface.php
+++ b/app/Services/Location/Interfaces/LocationCachedRepositoryInterface.php
@@ -22,9 +22,10 @@ interface LocationCachedRepositoryInterface
      *
      * @param  array  $conditions
      * @param  array  $filters
+     * @param  string  $path
      * @return Location|Collection|static[]|static|null
      */
-    public function searchCached(array $conditions = [], array $filters = []);
+    public function searchCached(array $conditions = [], array $filters = [], string $path = '');
 
     /**
      * Clear search cache.

--- a/app/Services/Location/Interfaces/LocationCachedRepositoryInterface.php
+++ b/app/Services/Location/Interfaces/LocationCachedRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Location\Interfaces;
+
+use App\Models\Location;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Interface LocationCachedRepositoryInterface
+ *
+ * @package App\Repositories\Interfaces
+ * @todo Добавить тайпхинты для возвращаемых значений
+ * @todo Разбить интерфейс на несколько меньших интерфейсов для соответствия ISP
+ */
+interface LocationCachedRepositoryInterface
+{
+    /**
+     * Find and paginate a cached collection of records.
+     *
+     * @param  array  $conditions
+     * @param  array  $filters
+     * @return Location|Collection|static[]|static|null
+     */
+    public function searchCached(array $conditions = [], array $filters = []);
+
+}

--- a/app/Services/Location/Interfaces/LocationRepositoryInterface.php
+++ b/app/Services/Location/Interfaces/LocationRepositoryInterface.php
@@ -21,9 +21,10 @@ interface LocationRepositoryInterface
      *
      * @param  array  $conditions
      * @param  array  $filters
+     * @param  string  $path
      * @return Location|Collection|static[]|static|null
      */
-    public function search(array $conditions = [], array $filters = []);
+    public function search(array $conditions = [], array $filters = [], string $path = '');
 
     /**
      * Find a record by its primary key.

--- a/app/Services/Location/Interfaces/LocationRepositoryInterface.php
+++ b/app/Services/Location/Interfaces/LocationRepositoryInterface.php
@@ -20,9 +20,10 @@ interface LocationRepositoryInterface
      * Find and paginate a collection of records.
      *
      * @param  array  $conditions
+     * @param  array  $filters
      * @return Location|Collection|static[]|static|null
      */
-    public function search(array $conditions = []);
+    public function search(array $conditions = [], array $filters = []);
 
     /**
      * Find a record by its primary key.

--- a/app/Services/Location/Interfaces/LocationServiceInterface.php
+++ b/app/Services/Location/Interfaces/LocationServiceInterface.php
@@ -15,12 +15,22 @@ use Illuminate\Database\Eloquent\Collection;
 interface LocationServiceInterface extends LocationRepositoryInterface
 {
     /**
-     * Find a record by User.
+     * Find records by User.
      *
      * @param  User  $user
+     * @param  array  $filters
      * @return Location|Collection|static[]|static|null
      */
-    public function getByUser(User $user);
+    public function getByUser(User $user, array $filters = []);
+
+    /**
+     * Find cached records by User.
+     *
+     * @param  User  $user
+     * @param  array  $filters
+     * @return Location|Collection|static[]|static|null
+     */
+    public function getByUserCached(User $user, array $filters = []);
 
     /**
      * Find a record by Workout.

--- a/app/Services/Location/Interfaces/LocationServiceInterface.php
+++ b/app/Services/Location/Interfaces/LocationServiceInterface.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Collection;
 /**
  * Interface LocationServiceInterface
  */
-interface LocationServiceInterface extends LocationRepositoryInterface
+interface LocationServiceInterface extends LocationRepositoryInterface, LocationCachedRepositoryInterface
 {
     /**
      * Find records by User.

--- a/app/Services/Location/LocationService.php
+++ b/app/Services/Location/LocationService.php
@@ -151,4 +151,13 @@ class LocationService implements LocationServiceInterface
     {
         $this->locationCachedRepository->clearSearchCache($conditions);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function warmupCacheByUser(User $user)
+    {
+        $this->locationCachedRepository->warmupCacheByUser($user);
+    }
+
 }

--- a/app/Services/Location/LocationService.php
+++ b/app/Services/Location/LocationService.php
@@ -143,4 +143,12 @@ class LocationService implements LocationServiceInterface
     {
         // TODO
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function clearSearchCache(array $conditions = ['user_id' => 0])
+    {
+        $this->locationCachedRepository->clearSearchCache($conditions);
+    }
 }

--- a/app/Services/Location/LocationService.php
+++ b/app/Services/Location/LocationService.php
@@ -44,9 +44,10 @@ class LocationService implements LocationServiceInterface
      *
      * @param  array  $conditions
      * @param  array  $filters
+     * @param  string  $path
      * @return Location|Collection|static[]|static|null
      */
-    public function search(array $conditions = [], array $filters = [])
+    public function search(array $conditions = [], array $filters = [], string $path = '')
     {
         return $this->locationRepository->search($conditions, $filters);
     }
@@ -56,9 +57,10 @@ class LocationService implements LocationServiceInterface
      *
      * @param  array  $conditions
      * @param  array  $filters
+     * @param  string  $path
      * @return Location|Collection|static[]|static|null
      */
-    public function searchCached(array $conditions = [], array $filters = [])
+    public function searchCached(array $conditions = [], array $filters = [], string $path = '')
     {
         return $this->locationCachedRepository->searchCached($conditions, $filters);
     }

--- a/app/Services/Location/LocationService.php
+++ b/app/Services/Location/LocationService.php
@@ -8,10 +8,12 @@ use App\Services\Location\Interfaces\LocationServiceInterface;
 use App\Models\Location;
 use App\Models\User;
 use App\Models\Workout;
+use App\Services\Location\Repositories\LocationCachedRepository;
 use App\Services\Location\Repositories\LocationRepository;
 use Illuminate\Database\Eloquent\Collection;
 
-class LocationService implements LocationServiceInterface {
+class LocationService implements LocationServiceInterface
+{
 
     /**
      * @var LocationRepository
@@ -19,24 +21,46 @@ class LocationService implements LocationServiceInterface {
     private $locationRepository;
 
     /**
+     * @var LocationCachedRepository $locationCachedRepository
+     */
+    private $locationCachedRepository;
+
+    /**
      * LocationService constructor.
      *
      * @param  LocationRepository  $locationRepository
+     * @param  LocationCachedRepository  $locationCachedRepository
      */
-    public function __construct(LocationRepository $locationRepository)
-    {
+    public function __construct(
+        LocationRepository $locationRepository,
+        LocationCachedRepository $locationCachedRepository
+    ) {
         $this->locationRepository = $locationRepository;
+        $this->locationCachedRepository = $locationCachedRepository;
     }
 
     /**
      * Find and paginate a collection of records.
      *
      * @param  array  $conditions
+     * @param  array  $filters
      * @return Location|Collection|static[]|static|null
      */
-    public function search(array $conditions = [])
+    public function search(array $conditions = [], array $filters = [])
     {
-        return $this->locationRepository->search($conditions);
+        return $this->locationRepository->search($conditions, $filters);
+    }
+
+    /**
+     * Find and paginate a collection of records.
+     *
+     * @param  array  $conditions
+     * @param  array  $filters
+     * @return Location|Collection|static[]|static|null
+     */
+    public function searchCached(array $conditions = [], array $filters = [])
+    {
+        return $this->locationCachedRepository->searchCached($conditions, $filters);
     }
 
     /**
@@ -89,11 +113,24 @@ class LocationService implements LocationServiceInterface {
      * Find all of the records by User.
      *
      * @param  User  $user
+     * @param  array  $filters
      * @return Location|Collection|static[]|static|null
      */
-    public function getByUser(User $user)
+    public function getByUser(User $user, array $filters = [])
     {
-        return $this->search(['user_id' => $user->id]);
+        return $this->search(['user_id' => $user->id], $filters);
+    }
+
+    /**
+     * Find cached records by User.
+     *
+     * @param  User  $user
+     * @param  array  $filters
+     * @return Location|Collection|static[]|static|null
+     */
+    public function getByUserCached(User $user, array $filters = [])
+    {
+        return $this->searchCached(['user_id' => $user->id], $filters);
     }
 
     /**

--- a/app/Services/Location/Repositories/LocationCachedRepository.php
+++ b/app/Services/Location/Repositories/LocationCachedRepository.php
@@ -2,24 +2,24 @@
 
 declare(strict_types=1);
 
-namespace App\Services\Workout\Repositories;
+namespace App\Services\Location\Repositories;
 
 use App\Services\Cache\CacheService;
-use App\Services\Workout\Interfaces\WorkoutCachedRepositoryInterface;
-use App\Models\Workout;
+use App\Services\Location\Interfaces\LocationCachedRepositoryInterface;
+use App\Models\Location;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Cache;
 
-class WorkoutCachedRepository implements WorkoutCachedRepositoryInterface {
+class LocationCachedRepository implements LocationCachedRepositoryInterface {
 
     /**
-     * @var WorkoutRepository $workoutRepository
+     * @var LocationRepository $locationRepository
      */
-    private $workoutRepository;
+    private $locationRepository;
 
-    public function __construct(WorkoutRepository $workoutRepository)
+    public function __construct(LocationRepository $locationRepository)
     {
-        $this->workoutRepository = $workoutRepository;
+        $this->locationRepository = $locationRepository;
     }
 
     /**
@@ -27,7 +27,7 @@ class WorkoutCachedRepository implements WorkoutCachedRepositoryInterface {
      *
      * @param  array  $conditions
      * @param  array  $filters
-     * @return Workout|Collection|static[]|static|null
+     * @return Location|Collection|static[]|static|null
      */
     public function searchCached(array $conditions = [], array $filters = [])
     {
@@ -36,7 +36,7 @@ class WorkoutCachedRepository implements WorkoutCachedRepositoryInterface {
             $cacheKey,
             CacheService::CACHE_TTL,
             function () use ($conditions, $filters) {
-                return $this->workoutRepository->search($conditions, $filters);
+                return $this->locationRepository->search($conditions, $filters);
             }
         );
     }

--- a/app/Services/Location/Repositories/LocationCachedRepository.php
+++ b/app/Services/Location/Repositories/LocationCachedRepository.php
@@ -45,4 +45,17 @@ class LocationCachedRepository implements LocationCachedRepositoryInterface {
         );
     }
 
+    /**
+     * Clear search cache.
+     *
+     * @param  array  $conditions
+     *   - user_id
+     */
+    public function clearSearchCache(array $conditions = ['user_id' => 0])
+    {
+        Cache::tags([
+            'Location.User:'.$conditions['user_id']
+        ])->flush();
+    }
+
 }

--- a/app/Services/Location/Repositories/LocationCachedRepository.php
+++ b/app/Services/Location/Repositories/LocationCachedRepository.php
@@ -26,13 +26,17 @@ class LocationCachedRepository implements LocationCachedRepositoryInterface {
      * Find and paginate a cached collection of records.
      *
      * @param  array  $conditions
+     *   - user_id
      * @param  array  $filters
      * @return Location|Collection|static[]|static|null
      */
-    public function searchCached(array $conditions = [], array $filters = [])
+    public function searchCached(array $conditions = ['user_id' => 0], array $filters = [])
     {
         $cacheKey = CacheService::getCacheKey(array_merge($conditions, $filters));
-        return Cache::remember(
+
+        return Cache::tags([
+            'Location.User:'.$conditions['user_id']
+        ])->remember(
             $cacheKey,
             CacheService::CACHE_TTL,
             function () use ($conditions, $filters) {

--- a/app/Services/Location/Repositories/LocationCachedRepository.php
+++ b/app/Services/Location/Repositories/LocationCachedRepository.php
@@ -38,7 +38,7 @@ class LocationCachedRepository implements LocationCachedRepositoryInterface
         $cacheKey = CacheService::getCacheKey(array_merge($conditions, $filters));
 
         return Cache::tags([
-            'Location.User:'.$conditions['user_id']
+            CacheService::getCacheUserTagByModel(Location::class).$conditions['user_id']
         ])->remember(
             $cacheKey,
             CacheService::CACHE_TTL,
@@ -57,7 +57,7 @@ class LocationCachedRepository implements LocationCachedRepositoryInterface
     public function clearSearchCache(array $conditions = ['user_id' => 0])
     {
         Cache::tags([
-            'Location.User:'.$conditions['user_id']
+            CacheService::getCacheUserTagByModel(Location::class).$conditions['user_id']
         ])->flush();
     }
 

--- a/app/Services/Location/Repositories/LocationRepository.php
+++ b/app/Services/Location/Repositories/LocationRepository.php
@@ -15,16 +15,21 @@ class LocationRepository implements LocationRepositoryInterface {
      *
      * @param  array  $conditions
      * @param  array  $filters
+     * @param  string  $path
      * @return Location|Collection|static[]|static|null
      *
      * @todo Использовать $filters
      */
-    public function search(array $conditions = [], array $filters = [])
+    public function search(array $conditions = [], array $filters = [], string $path = '')
     {
-        return Location::where($conditions)
+        $result = Location::where($conditions)
             ->with('user')
             ->orderBy('created_at', 'desc')
             ->paginate();
+        if ($path !== '') {
+            $result->withPath($path);
+        }
+        return $result;
     }
 
     /**

--- a/app/Services/Location/Repositories/LocationRepository.php
+++ b/app/Services/Location/Repositories/LocationRepository.php
@@ -14,11 +14,17 @@ class LocationRepository implements LocationRepositoryInterface {
      * Find and paginate a collection of records.
      *
      * @param  array  $conditions
+     * @param  array  $filters
      * @return Location|Collection|static[]|static|null
+     *
+     * @todo Использовать $filters
      */
-    public function search(array $conditions = [])
+    public function search(array $conditions = [], array $filters = [])
     {
-        return Location::where($conditions)->paginate();
+        return Location::where($conditions)
+            ->with('user')
+            ->orderBy('created_at', 'desc')
+            ->paginate();
     }
 
     /**

--- a/app/Services/Workout/Interfaces/WorkoutCachedRepositoryInterface.php
+++ b/app/Services/Workout/Interfaces/WorkoutCachedRepositoryInterface.php
@@ -25,4 +25,12 @@ interface WorkoutCachedRepositoryInterface
      */
     public function searchCached(array $conditions = [], array $filters = []);
 
+    /**
+     * Clear search cache.
+     *
+     * @param  array  $conditions
+     *   - user_id
+     */
+    public function clearSearchCache(array $conditions = ['user_id' => 0]);
+
 }

--- a/app/Services/Workout/Interfaces/WorkoutCachedRepositoryInterface.php
+++ b/app/Services/Workout/Interfaces/WorkoutCachedRepositoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Workout\Interfaces;
+
+use App\Models\Workout;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Interface WorkoutRepositoryInterface
+ *
+ * @package App\Repositories\Interfaces
+ * @todo Добавить тайпхинты для возвращаемых значений
+ * @todo Разбить интерфейс на несколько меньших интерфейсов для соответствия ISP
+ */
+interface WorkoutCachedRepositoryInterface
+{
+    /**
+     * Find and paginate a cached collection of records.
+     *
+     * @param  array  $conditions
+     * @return Workout|Collection|static[]|static|null
+     */
+    public function searchCached(array $conditions = []);
+
+}

--- a/app/Services/Workout/Interfaces/WorkoutCachedRepositoryInterface.php
+++ b/app/Services/Workout/Interfaces/WorkoutCachedRepositoryInterface.php
@@ -20,8 +20,9 @@ interface WorkoutCachedRepositoryInterface
      * Find and paginate a cached collection of records.
      *
      * @param  array  $conditions
+     * @param  array  $filters
      * @return Workout|Collection|static[]|static|null
      */
-    public function searchCached(array $conditions = []);
+    public function searchCached(array $conditions = [], array $filters = []);
 
 }

--- a/app/Services/Workout/Interfaces/WorkoutCachedRepositoryInterface.php
+++ b/app/Services/Workout/Interfaces/WorkoutCachedRepositoryInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Workout\Interfaces;
 
+use App\Models\User;
 use App\Models\Workout;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -21,9 +22,10 @@ interface WorkoutCachedRepositoryInterface
      *
      * @param  array  $conditions
      * @param  array  $filters
+     * @param  string  $path
      * @return Workout|Collection|static[]|static|null
      */
-    public function searchCached(array $conditions = [], array $filters = []);
+    public function searchCached(array $conditions = [], array $filters = [], string $path = '');
 
     /**
      * Clear search cache.
@@ -32,5 +34,13 @@ interface WorkoutCachedRepositoryInterface
      *   - user_id
      */
     public function clearSearchCache(array $conditions = ['user_id' => 0]);
+
+    /**
+     * Warmup cache by user.
+     *
+     * @param  User  $user
+     * @return mixed
+     */
+    public function warmupCacheByUser(User $user);
 
 }

--- a/app/Services/Workout/Interfaces/WorkoutRepositoryInterface.php
+++ b/app/Services/Workout/Interfaces/WorkoutRepositoryInterface.php
@@ -21,9 +21,10 @@ interface WorkoutRepositoryInterface
      *
      * @param  array  $conditions
      * @param  array  $filters
+     * @param  string  $path
      * @return Workout|Collection|static[]|static|null
      */
-    public function search(array $conditions = [], array $filters = []);
+    public function search(array $conditions = [], array $filters = [], string $path = '');
 
     /**
      * Find a record by its primary key.

--- a/app/Services/Workout/Interfaces/WorkoutRepositoryInterface.php
+++ b/app/Services/Workout/Interfaces/WorkoutRepositoryInterface.php
@@ -20,9 +20,10 @@ interface WorkoutRepositoryInterface
      * Find and paginate a collection of records.
      *
      * @param  array  $conditions
+     * @param  array  $filters
      * @return Workout|Collection|static[]|static|null
      */
-    public function search(array $conditions = []);
+    public function search(array $conditions = [], array $filters = []);
 
     /**
      * Find a record by its primary key.

--- a/app/Services/Workout/Interfaces/WorkoutServiceInterface.php
+++ b/app/Services/Workout/Interfaces/WorkoutServiceInterface.php
@@ -12,10 +12,10 @@ use Illuminate\Database\Eloquent\Collection;
 /**
  * Interface WorkoutServiceInterface
  */
-interface WorkoutServiceInterface extends WorkoutRepositoryInterface
+interface WorkoutServiceInterface extends WorkoutRepositoryInterface, WorkoutCachedRepositoryInterface
 {
     /**
-     * Find a record by User.
+     * Find records by User.
      *
      * @param  User  $user
      * @return Workout|Collection|static[]|static|null
@@ -23,7 +23,15 @@ interface WorkoutServiceInterface extends WorkoutRepositoryInterface
     public function getByUser(User $user);
 
     /**
-     * Find a record by Location.
+     * Find cached records by User.
+     *
+     * @param  User  $user
+     * @return Workout|Collection|static[]|static|null
+     */
+    public function getByUserCached(User $user);
+
+    /**
+     * Find records by Location.
      *
      * @param  Location  $location
      * @return Workout|Collection|static[]|static|null

--- a/app/Services/Workout/Interfaces/WorkoutServiceInterface.php
+++ b/app/Services/Workout/Interfaces/WorkoutServiceInterface.php
@@ -18,17 +18,19 @@ interface WorkoutServiceInterface extends WorkoutRepositoryInterface, WorkoutCac
      * Find records by User.
      *
      * @param  User  $user
+     * @param  array  $filters
      * @return Workout|Collection|static[]|static|null
      */
-    public function getByUser(User $user);
+    public function getByUser(User $user, array $filters = []);
 
     /**
      * Find cached records by User.
      *
      * @param  User  $user
+     * @param  array  $filters
      * @return Workout|Collection|static[]|static|null
      */
-    public function getByUserCached(User $user);
+    public function getByUserCached(User $user, array $filters = []);
 
     /**
      * Find records by Location.

--- a/app/Services/Workout/Repositories/WorkoutCachedRepository.php
+++ b/app/Services/Workout/Repositories/WorkoutCachedRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Workout\Repositories;
+
+use App\Services\Cache\CacheKeyService;
+use App\Services\Workout\Interfaces\WorkoutCachedRepositoryInterface;
+use App\Models\Workout;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Cache;
+
+class WorkoutCachedRepository implements WorkoutCachedRepositoryInterface {
+
+    /**
+     * @var WorkoutRepository $workoutRepository
+     */
+    private $workoutRepository;
+
+    public function __construct(WorkoutRepository $workoutRepository)
+    {
+        $this->workoutRepository = $workoutRepository;
+    }
+
+    /**
+     * Find and paginate a cached collection of records.
+     *
+     * @param  array  $conditions
+     * @return Workout|Collection|static[]|static|null
+     */
+    public function searchCached(array $conditions = [])
+    {
+        $cacheKey = CacheKeyService::getCacheKey($conditions);
+        return Cache::remember(
+            $cacheKey,
+            CacheKeyService::CACHE_TTL,
+            function () use ($conditions) {
+                return $this->workoutRepository->search($conditions);
+            }
+        );
+    }
+
+}

--- a/app/Services/Workout/Repositories/WorkoutCachedRepository.php
+++ b/app/Services/Workout/Repositories/WorkoutCachedRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Workout\Repositories;
 
-use App\Services\Cache\CacheKeyService;
+use App\Services\Cache\CacheService;
 use App\Services\Workout\Interfaces\WorkoutCachedRepositoryInterface;
 use App\Models\Workout;
 use Illuminate\Database\Eloquent\Collection;
@@ -26,14 +26,15 @@ class WorkoutCachedRepository implements WorkoutCachedRepositoryInterface {
      * Find and paginate a cached collection of records.
      *
      * @param  array  $conditions
+     * @param  array  $filters
      * @return Workout|Collection|static[]|static|null
      */
-    public function searchCached(array $conditions = [])
+    public function searchCached(array $conditions = [], array $filters = [])
     {
-        $cacheKey = CacheKeyService::getCacheKey($conditions);
+        $cacheKey = CacheService::getCacheKey(array_merge($conditions, $filters));
         return Cache::remember(
             $cacheKey,
-            CacheKeyService::CACHE_TTL,
+            CacheService::CACHE_TTL,
             function () use ($conditions) {
                 return $this->workoutRepository->search($conditions);
             }

--- a/app/Services/Workout/Repositories/WorkoutCachedRepository.php
+++ b/app/Services/Workout/Repositories/WorkoutCachedRepository.php
@@ -26,13 +26,17 @@ class WorkoutCachedRepository implements WorkoutCachedRepositoryInterface {
      * Find and paginate a cached collection of records.
      *
      * @param  array  $conditions
+     *   - user_id
      * @param  array  $filters
      * @return Workout|Collection|static[]|static|null
      */
-    public function searchCached(array $conditions = [], array $filters = [])
+    public function searchCached(array $conditions = ['user_id' => 0], array $filters = [])
     {
         $cacheKey = CacheService::getCacheKey(array_merge($conditions, $filters));
-        return Cache::remember(
+
+        return Cache::tags([
+            'Workout.User:'.$conditions['user_id']
+        ])->remember(
             $cacheKey,
             CacheService::CACHE_TTL,
             function () use ($conditions, $filters) {

--- a/app/Services/Workout/Repositories/WorkoutCachedRepository.php
+++ b/app/Services/Workout/Repositories/WorkoutCachedRepository.php
@@ -45,4 +45,17 @@ class WorkoutCachedRepository implements WorkoutCachedRepositoryInterface {
         );
     }
 
+    /**
+     * Clear search cache.
+     *
+     * @param  array  $conditions
+     *   - user_id
+     */
+    public function clearSearchCache(array $conditions = ['user_id' => 0])
+    {
+        Cache::tags([
+            'Workout.User:'.$conditions['user_id']
+        ])->flush();
+    }
+
 }

--- a/app/Services/Workout/Repositories/WorkoutCachedRepository.php
+++ b/app/Services/Workout/Repositories/WorkoutCachedRepository.php
@@ -37,7 +37,7 @@ class WorkoutCachedRepository implements WorkoutCachedRepositoryInterface {
         $cacheKey = CacheService::getCacheKey(array_merge($conditions, $filters));
 
         return Cache::tags([
-            'Workout.User:'.$conditions['user_id']
+            CacheService::getCacheUserTagByModel(Workout::class).$conditions['user_id']
         ])->remember(
             $cacheKey,
             CacheService::CACHE_TTL,
@@ -56,7 +56,7 @@ class WorkoutCachedRepository implements WorkoutCachedRepositoryInterface {
     public function clearSearchCache(array $conditions = ['user_id' => 0])
     {
         Cache::tags([
-            'Workout.User:'.$conditions['user_id']
+            CacheService::getCacheUserTagByModel(Workout::class).$conditions['user_id']
         ])->flush();
     }
 

--- a/app/Services/Workout/Repositories/WorkoutRepository.php
+++ b/app/Services/Workout/Repositories/WorkoutRepository.php
@@ -15,17 +15,22 @@ class WorkoutRepository implements WorkoutRepositoryInterface {
      *
      * @param  array  $conditions
      * @param  array  $filters
+     * @param  string  $path
      * @return Workout|Collection|static[]|static|null
      *
      * @todo Использовать $filters
      */
-    public function search(array $conditions = [], array $filters = [])
+    public function search(array $conditions = [], array $filters = [], string $path = '')
     {
-        return Workout::where($conditions)
+        $result = Workout::where($conditions)
             ->with('user')
             ->with('location')
             ->orderBy('started_at', 'desc')
             ->paginate();
+        if ($path !== '') {
+            $result->withPath($path);
+        }
+        return $result;
     }
 
     /**

--- a/app/Services/Workout/Repositories/WorkoutRepository.php
+++ b/app/Services/Workout/Repositories/WorkoutRepository.php
@@ -24,7 +24,6 @@ class WorkoutRepository implements WorkoutRepositoryInterface {
         return Workout::where($conditions)
             ->with('user')
             ->orderBy('started_at', 'desc')
-            ->orderBy('id', 'desc')
             ->paginate();
     }
 

--- a/app/Services/Workout/Repositories/WorkoutRepository.php
+++ b/app/Services/Workout/Repositories/WorkoutRepository.php
@@ -18,7 +18,7 @@ class WorkoutRepository implements WorkoutRepositoryInterface {
      */
     public function search(array $conditions = [])
     {
-        return Workout::where($conditions)->paginate();
+        return Workout::where($conditions)->with('user')->paginate();
     }
 
     /**

--- a/app/Services/Workout/Repositories/WorkoutRepository.php
+++ b/app/Services/Workout/Repositories/WorkoutRepository.php
@@ -23,6 +23,7 @@ class WorkoutRepository implements WorkoutRepositoryInterface {
     {
         return Workout::where($conditions)
             ->with('user')
+            ->with('location')
             ->orderBy('started_at', 'desc')
             ->paginate();
     }

--- a/app/Services/Workout/Repositories/WorkoutRepository.php
+++ b/app/Services/Workout/Repositories/WorkoutRepository.php
@@ -14,11 +14,18 @@ class WorkoutRepository implements WorkoutRepositoryInterface {
      * Find and paginate a collection of records.
      *
      * @param  array  $conditions
+     * @param  array  $filters
      * @return Workout|Collection|static[]|static|null
+     *
+     * @todo Использовать $filters
      */
-    public function search(array $conditions = [])
+    public function search(array $conditions = [], array $filters = [])
     {
-        return Workout::where($conditions)->with('user')->paginate();
+        return Workout::where($conditions)
+            ->with('user')
+            ->orderBy('started_at', 'desc')
+            ->orderBy('id', 'desc')
+            ->paginate();
     }
 
     /**

--- a/app/Services/Workout/WorkoutService.php
+++ b/app/Services/Workout/WorkoutService.php
@@ -8,24 +8,32 @@ use App\Models\Location;
 use App\Services\Workout\Interfaces\WorkoutServiceInterface;
 use App\Models\Workout;
 use App\Models\User;
+use App\Services\Workout\Repositories\WorkoutCachedRepository;
 use App\Services\Workout\Repositories\WorkoutRepository;
 use Illuminate\Database\Eloquent\Collection;
 
 class WorkoutService implements WorkoutServiceInterface {
 
     /**
-     * @var WorkoutRepository
+     * @var WorkoutRepository $workoutRepository
      */
     private $workoutRepository;
+
+    /**
+     * @var WorkoutCachedRepository $workoutCachedRepository
+     */
+    private $workoutCachedRepository;
 
     /**
      * WorkoutService constructor.
      *
      * @param  WorkoutRepository  $workoutRepository
+     * @param  WorkoutCachedRepository  $workoutCachedRepository
      */
-    public function __construct(WorkoutRepository $workoutRepository)
+    public function __construct(WorkoutRepository $workoutRepository, WorkoutCachedRepository $workoutCachedRepository)
     {
         $this->workoutRepository = $workoutRepository;
+        $this->workoutCachedRepository = $workoutCachedRepository;
     }
 
     /**
@@ -37,6 +45,17 @@ class WorkoutService implements WorkoutServiceInterface {
     public function search(array $conditions = [])
     {
         return $this->workoutRepository->search($conditions);
+    }
+
+    /**
+     * Find and paginate a collection of records.
+     *
+     * @param  array  $conditions
+     * @return Workout|Collection|static[]|static|null
+     */
+    public function searchCached(array $conditions = [])
+    {
+        return $this->workoutCachedRepository->searchCached($conditions);
     }
 
     /**
@@ -78,6 +97,7 @@ class WorkoutService implements WorkoutServiceInterface {
      *
      * @param  Workout  $workout
      * @return mixed
+     * @throws \Exception
      */
     public function delete(Workout $workout)
     {
@@ -85,7 +105,7 @@ class WorkoutService implements WorkoutServiceInterface {
     }
 
     /**
-     * Find a record by User.
+     * Find records by User.
      *
      * @param  User  $user
      * @return Workout|Collection|static[]|static|null
@@ -96,7 +116,18 @@ class WorkoutService implements WorkoutServiceInterface {
     }
 
     /**
-     * Find a record by Location.
+     * Find cached records by User.
+     *
+     * @param  User  $user
+     * @return Workout|Collection|static[]|static|null
+     */
+    public function getByUserCached(User $user)
+    {
+        return $this->searchCached(['user_id' => $user->id]);
+    }
+
+    /**
+     * Find records by Location.
      *
      * @param  Location  $location
      * @return Workout|Collection|static[]|static|null

--- a/app/Services/Workout/WorkoutService.php
+++ b/app/Services/Workout/WorkoutService.php
@@ -40,22 +40,24 @@ class WorkoutService implements WorkoutServiceInterface {
      * Find and paginate a collection of records.
      *
      * @param  array  $conditions
+     * @param  array  $filters
      * @return Workout|Collection|static[]|static|null
      */
-    public function search(array $conditions = [])
+    public function search(array $conditions = [], array $filters = [])
     {
-        return $this->workoutRepository->search($conditions);
+        return $this->workoutRepository->search($conditions, $filters);
     }
 
     /**
      * Find and paginate a collection of records.
      *
      * @param  array  $conditions
+     * @param  array  $filters
      * @return Workout|Collection|static[]|static|null
      */
-    public function searchCached(array $conditions = [])
+    public function searchCached(array $conditions = [], array $filters = [])
     {
-        return $this->workoutCachedRepository->searchCached($conditions);
+        return $this->workoutCachedRepository->searchCached($conditions, $filters);
     }
 
     /**
@@ -108,9 +110,10 @@ class WorkoutService implements WorkoutServiceInterface {
      * Find records by User.
      *
      * @param  User  $user
+     * @param  array  $filters
      * @return Workout|Collection|static[]|static|null
      */
-    public function getByUser(User $user)
+    public function getByUser(User $user, array $filters = [])
     {
         return $this->search(['user_id' => $user->id]);
     }
@@ -119,11 +122,12 @@ class WorkoutService implements WorkoutServiceInterface {
      * Find cached records by User.
      *
      * @param  User  $user
+     * @param  array  $filters
      * @return Workout|Collection|static[]|static|null
      */
-    public function getByUserCached(User $user)
+    public function getByUserCached(User $user, array $filters = [])
     {
-        return $this->searchCached(['user_id' => $user->id]);
+        return $this->searchCached(['user_id' => $user->id], $filters);
     }
 
     /**

--- a/app/Services/Workout/WorkoutService.php
+++ b/app/Services/Workout/WorkoutService.php
@@ -12,7 +12,8 @@ use App\Services\Workout\Repositories\WorkoutCachedRepository;
 use App\Services\Workout\Repositories\WorkoutRepository;
 use Illuminate\Database\Eloquent\Collection;
 
-class WorkoutService implements WorkoutServiceInterface {
+class WorkoutService implements WorkoutServiceInterface
+{
 
     /**
      * @var WorkoutRepository $workoutRepository
@@ -115,7 +116,7 @@ class WorkoutService implements WorkoutServiceInterface {
      */
     public function getByUser(User $user, array $filters = [])
     {
-        return $this->search(['user_id' => $user->id]);
+        return $this->search(['user_id' => $user->id], $filters);
     }
 
     /**

--- a/app/Services/Workout/WorkoutService.php
+++ b/app/Services/Workout/WorkoutService.php
@@ -42,9 +42,10 @@ class WorkoutService implements WorkoutServiceInterface
      *
      * @param  array  $conditions
      * @param  array  $filters
+     * @param  string  $path
      * @return Workout|Collection|static[]|static|null
      */
-    public function search(array $conditions = [], array $filters = [])
+    public function search(array $conditions = [], array $filters = [], string $path = '')
     {
         return $this->workoutRepository->search($conditions, $filters);
     }
@@ -54,9 +55,10 @@ class WorkoutService implements WorkoutServiceInterface
      *
      * @param  array  $conditions
      * @param  array  $filters
+     * @param  string  $path
      * @return Workout|Collection|static[]|static|null
      */
-    public function searchCached(array $conditions = [], array $filters = [])
+    public function searchCached(array $conditions = [], array $filters = [], string $path = '')
     {
         return $this->workoutCachedRepository->searchCached($conditions, $filters);
     }
@@ -148,5 +150,13 @@ class WorkoutService implements WorkoutServiceInterface
     public function clearSearchCache(array $conditions = ['user_id' => 0])
     {
         $this->workoutCachedRepository->clearSearchCache($conditions);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function warmupCacheByUser(User $user)
+    {
+        $this->workoutCachedRepository->warmupCacheByUser($user);
     }
 }

--- a/app/Services/Workout/WorkoutService.php
+++ b/app/Services/Workout/WorkoutService.php
@@ -141,4 +141,12 @@ class WorkoutService implements WorkoutServiceInterface
     {
         // TODO
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function clearSearchCache(array $conditions = ['user_id' => 0])
+    {
+        $this->workoutCachedRepository->clearSearchCache($conditions);
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "laravelcollective/html": "^6.0"
     },
     "require-dev": {
+        "barryvdh/laravel-debugbar": "^3.2",
         "filp/whoops": "^2.0",
         "fzaninotto/faker": "^1.4",
         "laravel/ui": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0fe087b6f35d71bbac204cf356585052",
+    "content-hash": "510d7a3753750f0b21361db5ecf492fc",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -2962,6 +2962,74 @@
     ],
     "packages-dev": [
         {
+            "name": "barryvdh/laravel-debugbar",
+            "version": "v3.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-debugbar.git",
+                "reference": "18208d64897ab732f6c04a19b319fe8f1d57a9c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/18208d64897ab732f6c04a19b319fe8f1d57a9c0",
+                "reference": "18208d64897ab732f6c04a19b319fe8f1d57a9c0",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/routing": "^5.5|^6",
+                "illuminate/session": "^5.5|^6",
+                "illuminate/support": "^5.5|^6",
+                "maximebf/debugbar": "~1.15.0",
+                "php": ">=7.0",
+                "symfony/debug": "^3|^4",
+                "symfony/finder": "^3|^4"
+            },
+            "require-dev": {
+                "laravel/framework": "5.5.x"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\Debugbar\\ServiceProvider"
+                    ],
+                    "aliases": {
+                        "Debugbar": "Barryvdh\\Debugbar\\Facade"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\Debugbar\\": "src/"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "PHP Debugbar integration for Laravel",
+            "keywords": [
+                "debug",
+                "debugbar",
+                "laravel",
+                "profiler",
+                "webprofiler"
+            ],
+            "time": "2019-08-29T07:01:03+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.2.0",
             "source": {
@@ -3232,6 +3300,67 @@
                 "ui"
             ],
             "time": "2019-10-11T12:16:52+00:00"
+        },
+        {
+            "name": "maximebf/debugbar",
+            "version": "v1.15.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maximebf/php-debugbar.git",
+                "reference": "6c4277f6117e4864966c9cb58fb835cee8c74a1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/6c4277f6117e4864966c9cb58fb835cee8c74a1e",
+                "reference": "6c4277f6117e4864966c9cb58fb835cee8c74a1e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "psr/log": "^1.0",
+                "symfony/var-dumper": "^2.6|^3|^4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5"
+            },
+            "suggest": {
+                "kriswallsmith/assetic": "The best way to manage assets",
+                "monolog/monolog": "Log using Monolog",
+                "predis/predis": "Redis storage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\": "src/DebugBar/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Debug bar in the browser for php application",
+            "homepage": "https://github.com/maximebf/php-debugbar",
+            "keywords": [
+                "debug",
+                "debugbar"
+            ],
+            "time": "2019-09-24T14:55:42+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Faker\Generator as Faker;
 
@@ -21,7 +22,7 @@ $factory->define(User::class, function (Faker $faker) {
         'name' => $faker->name,
         'email' => $faker->unique()->safeEmail,
         'email_verified_at' => now(),
-        'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+        'password' => Hash::make('password'),
         'remember_token' => Str::random(10),
     ];
 });

--- a/database/seeds/LocationsTableSeeder.php
+++ b/database/seeds/LocationsTableSeeder.php
@@ -12,7 +12,7 @@ class LocationsTableSeeder extends Seeder
     public function run()
     {
         foreach (\App\Models\User::all() as $user) {
-            factory(\App\Models\Location::class, 3)->create([
+            factory(\App\Models\Location::class, 30)->create([
                 'user_id' => $user->id,
             ]);
         }

--- a/database/seeds/WorkoutsTableSeeder.php
+++ b/database/seeds/WorkoutsTableSeeder.php
@@ -12,10 +12,13 @@ class WorkoutsTableSeeder extends Seeder
     public function run()
     {
         foreach (\App\Models\User::all() as $user) {
-            factory(\App\Models\Workout::class, 100)->create([
-                'user_id' => $user->id,
-                'location_id' => $user->locations()->inRandomOrder()->first()->id,
-            ]);
+            for ($i = 0; $i < 100; $i++) {
+                $locationId = rand(0, 1) ? $user->locations()->inRandomOrder()->first()->id : null;
+                factory(\App\Models\Workout::class, 1)->create([
+                    'user_id' => $user->id,
+                    'location_id' => $locationId,
+                ]);
+            }
         }
     }
 }

--- a/database/seeds/WorkoutsTableSeeder.php
+++ b/database/seeds/WorkoutsTableSeeder.php
@@ -12,7 +12,7 @@ class WorkoutsTableSeeder extends Seeder
     public function run()
     {
         foreach (\App\Models\User::all() as $user) {
-            factory(\App\Models\Workout::class, 10)->create([
+            factory(\App\Models\Workout::class, 100)->create([
                 'user_id' => $user->id,
                 'location_id' => $user->locations()->inRandomOrder()->first()->id,
             ]);

--- a/resources/views/backend/pages/location/index.blade.php
+++ b/resources/views/backend/pages/location/index.blade.php
@@ -20,7 +20,6 @@
                     <th scope="col">ID</th>
                     <th scope="col">Name</th>
                     <th scope="col">Distance</th>
-                    <th scope="col">User</th>
                     <th scope="col">Created</th>
                 </tr>
                 </thead>
@@ -30,7 +29,6 @@
                         <th scope="row">{{ $location->id }}</th>
                         <th>{{ link_to(route('backend.location.edit', ['location' => $location->id]), $location->name) }}</th>
                         <th>{{ $location->distance }}</th>
-                        <th>{{ $location->user->name }}</th>
                         <td>{{ $location->created_at }}</td>
                     </tr>
                 @endforeach

--- a/resources/views/backend/pages/workout/index.blade.php
+++ b/resources/views/backend/pages/workout/index.blade.php
@@ -21,7 +21,7 @@
                     <th scope="col">Name</th>
                     <th scope="col">Distance</th>
                     <th scope="col">Started</th>
-                    <th scope="col">Duration</th>
+                    <th scope="col">Location</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -31,7 +31,7 @@
                         <th>{{ link_to(route('backend.workout.edit', ['workout' => $workout->id]), $workout->name) }}</th>
                         <th>{{ $workout->distance }}</th>
                         <td>{{ $workout->started_at }}</td>
-                        <td>{{ $workout->duration }}</td>
+                        <td>{{ $workout->location->name ?? '–' }}</td>
                     </tr>
                 @endforeach
                 </tbody>

--- a/resources/views/backend/pages/workout/index.blade.php
+++ b/resources/views/backend/pages/workout/index.blade.php
@@ -20,8 +20,8 @@
                     <th scope="col">ID</th>
                     <th scope="col">Name</th>
                     <th scope="col">Distance</th>
-                    <th scope="col">User</th>
-                    <th scope="col">Created</th>
+                    <th scope="col">Started</th>
+                    <th scope="col">Duration</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -30,8 +30,8 @@
                         <th scope="row">{{ $workout->id }}</th>
                         <th>{{ link_to(route('backend.workout.edit', ['workout' => $workout->id]), $workout->name) }}</th>
                         <th>{{ $workout->distance }}</th>
-                        <th>{{ $workout->user->name }}</th>
-                        <td>{{ $workout->created_at }}</td>
+                        <td>{{ $workout->started_at }}</td>
+                        <td>{{ $workout->duration }}</td>
                     </tr>
                 @endforeach
                 </tbody>

--- a/storage/debugbar/.gitignore
+++ b/storage/debugbar/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Feature/Console/Commands/WarmupCacheTest.php
+++ b/tests/Feature/Console/Commands/WarmupCacheTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Models\User;
+use Tests\TestCase;
+
+class WarmupCacheTest extends TestCase
+{
+    /**
+     * Create User instance.
+     *
+     * @return User
+     */
+    private function createUser(): User
+    {
+        return factory(User::class)->create();
+    }
+
+    /**
+     * A basic test example.
+     *
+     * @return void
+     */
+    public function testWarmupCache()
+    {
+        $user = $this->createUser();
+
+        $this->artisan('cache:warmup')
+            ->expectsOutput('Warmed up cache for '.$user->name)
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Feature/Console/Commands/WarmupCacheTest.php
+++ b/tests/Feature/Console/Commands/WarmupCacheTest.php
@@ -3,10 +3,13 @@
 namespace Tests\Feature\Console\Commands;
 
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class WarmupCacheTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
      * Create User instance.
      *
@@ -18,7 +21,7 @@ class WarmupCacheTest extends TestCase
     }
 
     /**
-     * A basic test example.
+     * Test Artisan cache:warmup command.
      *
      * @return void
      */
@@ -30,4 +33,17 @@ class WarmupCacheTest extends TestCase
             ->expectsOutput('Warmed up cache for '.$user->name)
             ->assertExitCode(0);
     }
+
+    /**
+     * Test Artisan cache:warmup command (no users).
+     *
+     * @return void
+     */
+    public function testWarmupCacheNoUsers()
+    {
+        $this->artisan('cache:warmup')
+            ->expectsOutput('No users found')
+            ->assertExitCode(0);
+    }
+
 }

--- a/tests/Unit/Services/Cache/CacheKeyServiceTest.php
+++ b/tests/Unit/Services/Cache/CacheKeyServiceTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\Services\Cache;
+
+use App\Services\Cache\CacheKeyService;
+use Tests\TestCase;
+
+class CacheKeyServiceTest extends TestCase
+{
+
+    /**
+     * Test CacheKeyService::getCacheKey() method.
+     *
+     * @return void
+     */
+    public function testGetCacheKey(): void {
+        $params = [
+            'page' => 1
+        ];
+        $cacheKey = CacheKeyService::getCacheKey($params);
+        $this->assertEquals('cache.params:page=1', $cacheKey);
+    }
+
+}

--- a/tests/Unit/Services/Cache/CacheKeyServiceTest.php
+++ b/tests/Unit/Services/Cache/CacheKeyServiceTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Unit\Services\Cache;
 
-use App\Services\Cache\CacheKeyService;
+use App\Services\Cache\CacheService;
 use Tests\TestCase;
 
 class CacheKeyServiceTest extends TestCase
 {
 
     /**
-     * Test CacheKeyService::getCacheKey() method.
+     * Test CacheService::getCacheKey() method.
      *
      * @return void
      */
@@ -17,7 +17,7 @@ class CacheKeyServiceTest extends TestCase
         $params = [
             'page' => 1
         ];
-        $cacheKey = CacheKeyService::getCacheKey($params);
+        $cacheKey = CacheService::getCacheKey($params);
         $this->assertEquals('cache.params:page=1', $cacheKey);
     }
 

--- a/tests/Unit/Services/Cache/CacheServiceTest.php
+++ b/tests/Unit/Services/Cache/CacheServiceTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Cache;
 use App\Services\Cache\CacheService;
 use Tests\TestCase;
 
-class CacheKeyServiceTest extends TestCase
+class CacheServiceTest extends TestCase
 {
 
     /**

--- a/tests/Unit/Services/Location/LocationServiceTest.php
+++ b/tests/Unit/Services/Location/LocationServiceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Unit\Services\Location;
+
+use App\Services\User\UserService;
+use App\Services\Location\LocationService;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class LocationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Default values for Location
+     */
+    const DEFAULT_DATA_LOCATION = [
+        'name' => 'Test Location',
+        'distance' => 10000,
+    ];
+
+    /**
+     * Default values for User
+     */
+    const DEFAULT_DATA_USER = [
+        'name' => 'Test User',
+        'email' => 'test@localhost',
+        'password' => 'Str0ngPassw0rd',
+    ];
+
+    /**
+     * @var LocationService $locationService
+     */
+    private $locationService;
+
+    /**
+     * @var UserService $userService
+     */
+    private $userService;
+
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->locationService = $this->app->make('App\Services\Location\LocationService');
+        $this->userService = $this->app->make('App\Services\User\UserService');
+    }
+
+    /**
+     * Test LocationService::getByUser() method.
+     *
+     * @return void
+     */
+    public function testGetByUser(): void {
+
+        $data = self::DEFAULT_DATA_USER;
+        $user = $this->userService->create($data);
+
+        $data = self::DEFAULT_DATA_LOCATION;
+        $data['user_id'] = $user->id;
+        $location = $this->locationService->create($data);
+
+        $result = $this->locationService->getByUser($user);
+        $this->assertEquals(1, $result->count());
+        $this->assertEquals($location->id, $result->first()->id);
+    }
+
+    /**
+     * Test LocationService::getByUserCached() method.
+     *
+     * @return void
+     */
+    public function testGetByUserCached(): void {
+
+        Cache::flush();
+
+        $data = self::DEFAULT_DATA_USER;
+        $user = $this->userService->create($data);
+
+        $data = self::DEFAULT_DATA_LOCATION;
+        $data['user_id'] = $user->id;
+        $location = $this->locationService->create($data);
+
+        $result = $this->locationService->getByUserCached($user);
+        $this->assertEquals(1, $result->count());
+        $this->assertEquals($location->id, $result->first()->id);
+    }
+
+}

--- a/tests/Unit/Services/Workout/WorkoutServiceTest.php
+++ b/tests/Unit/Services/Workout/WorkoutServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Unit\Services\Workout;
+
+use App\Services\User\UserService;
+use App\Services\Workout\WorkoutService;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class WorkoutServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Default values for Workout
+     */
+    const DEFAULT_DATA_WORKOUT = [
+        'name' => 'Test Workout',
+        'distance' => 10000,
+        'started_at' => '2019-01-01 00:00:00',
+        'duration' => 200,
+    ];
+
+    /**
+     * Default values for User
+     */
+    const DEFAULT_DATA_USER = [
+        'name' => 'Test User',
+        'email' => 'test@localhost',
+        'password' => 'Str0ngPassw0rd',
+    ];
+
+    /**
+     * @var WorkoutService $workoutService
+     */
+    private $workoutService;
+
+    /**
+     * @var UserService $userService
+     */
+    private $userService;
+
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->workoutService = $this->app->make('App\Services\Workout\WorkoutService');
+        $this->userService = $this->app->make('App\Services\User\UserService');
+    }
+
+    /**
+     * Test WorkoutService::getByUser() method.
+     *
+     * @return void
+     */
+    public function testGetByUser(): void {
+
+        $data = self::DEFAULT_DATA_USER;
+        $user = $this->userService->create($data);
+
+        $data = self::DEFAULT_DATA_WORKOUT;
+        $data['user_id'] = $user->id;
+        $workout = $this->workoutService->create($data);
+
+        $result = $this->workoutService->getByUser($user);
+        $this->assertEquals(1, $result->count());
+        $this->assertEquals($workout->id, $result->first()->id);
+    }
+
+    /**
+     * Test WorkoutService::getByUserCached() method.
+     *
+     * @return void
+     */
+    public function testGetByUserCached(): void {
+
+        Cache::flush();
+
+        $data = self::DEFAULT_DATA_USER;
+        $user = $this->userService->create($data);
+
+        $data = self::DEFAULT_DATA_WORKOUT;
+        $data['user_id'] = $user->id;
+        $workout = $this->workoutService->create($data);
+
+        $result = $this->workoutService->getByUserCached($user);
+        $this->assertEquals(1, $result->count());
+        $this->assertEquals($workout->id, $result->first()->id);
+    }
+
+}

--- a/tests/Unit/Services/Workout/WorkoutServiceTest.php
+++ b/tests/Unit/Services/Workout/WorkoutServiceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Services\Workout;
 use App\Services\User\UserService;
 use App\Services\Workout\WorkoutService;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -89,6 +90,43 @@ class WorkoutServiceTest extends TestCase
         $result = $this->workoutService->getByUserCached($user);
         $this->assertEquals(1, $result->count());
         $this->assertEquals($workout->id, $result->first()->id);
+    }
+
+    /**
+     * Test WorkoutService::clearSearchCache() method.
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testClearSearchCache(): void {
+
+        Cache::flush();
+        $newName = 'Test Workout 2';
+
+        $data = self::DEFAULT_DATA_USER;
+        $user = $this->userService->create($data);
+
+        $data = self::DEFAULT_DATA_WORKOUT;
+        $data['user_id'] = $user->id;
+        $workout = $this->workoutService->create($data);
+
+        $result = $this->workoutService->getByUserCached($user);
+        $this->assertEquals(1, $result->count());
+        $this->assertEquals($workout->id, $result->first()->id);
+
+        // Update name in database (directly)
+        DB::table('workouts')
+            ->where('id', $workout->id)
+            ->update(['name' => $newName]);
+        // Old name is still cached
+        $result = $this->workoutService->getByUserCached($user);
+        $this->assertEquals(self::DEFAULT_DATA_WORKOUT['name'], $result->first()->name);
+
+        // Clear cache and verify name
+        $this->workoutService->clearSearchCache(['user_id' => $user->id]);
+        $result = $this->workoutService->getByUserCached($user);
+        $this->assertEquals($newName, $result->first()->name);
+
     }
 
 }


### PR DESCRIPTION
Этот PR включает в себя сразу два д/з – по кэшированию и командам.

Кэширование реализовано для списков сущностей. Кэш инвалидируется по тэгу при сохранении или удалении сущности. Тэги, в свою очередь, привязаны к имени модели + к идентификатору пользователя – благодаря этому у каждого пользователя есть свой независимый кэш.

Прогрев кэша реализован для первой страницы списка сущностей. Он выполняется командой:

`php artisan cache:warmup`

Код покрыт тестами. Текущее покрытие – 95% files, 90% lines.