### PR TITLE
Д/з: Пакеты

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use DmitryKirillov\ActivityParserLaravel\Console\Commands\ParseTCX;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +24,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $this->commands([
+            ParseTCX::class
+        ]);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
+        "dmitrykirillov/activity-parser-laravel": "dev-master",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "^6.0",
         "laravel/tinker": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "dmitrykirillov/activity-parser-laravel": "dev-master",
+        "dmitrykirillov/activity-parser-laravel": "^0.0.1@alpha",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "^6.0",
         "laravel/tinker": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ba3c34791e4fb39a76b39f36dcdad08",
+    "content-hash": "fe41e3f298402d3a93aad1d2f19b8060",
     "packages": [
         {
             "name": "dmitrykirillov/activity-parser",
@@ -55,16 +55,16 @@
         },
         {
             "name": "dmitrykirillov/activity-parser-laravel",
-            "version": "dev-master",
+            "version": "v0.0.1-alpha",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DmitryKirillov/activity-parser-laravel.git",
-                "reference": "f9fc019b6fcd6898aa34c82c36b406d7b8d688f2"
+                "reference": "ae5c0bceee7ec94ad14e1f9a61f9a40a8c81d19b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DmitryKirillov/activity-parser-laravel/zipball/f9fc019b6fcd6898aa34c82c36b406d7b8d688f2",
-                "reference": "f9fc019b6fcd6898aa34c82c36b406d7b8d688f2",
+                "url": "https://api.github.com/repos/DmitryKirillov/activity-parser-laravel/zipball/ae5c0bceee7ec94ad14e1f9a61f9a40a8c81d19b",
+                "reference": "ae5c0bceee7ec94ad14e1f9a61f9a40a8c81d19b",
                 "shasum": ""
             },
             "require": {
@@ -98,7 +98,7 @@
                 }
             ],
             "description": "Laravel package for PHP parser for files created by fitness app",
-            "time": "2019-12-28T16:04:16+00:00"
+            "time": "2019-12-28T17:11:08+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -4994,7 +4994,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "dmitrykirillov/activity-parser-laravel": 20
+        "dmitrykirillov/activity-parser-laravel": 15
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,102 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "510d7a3753750f0b21361db5ecf492fc",
+    "content-hash": "2ba3c34791e4fb39a76b39f36dcdad08",
     "packages": [
+        {
+            "name": "dmitrykirillov/activity-parser",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DmitryKirillov/activity-parser.git",
+                "reference": "5e7ad3baf6b7e766c0fb2c5eaf01f70a59b5de00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DmitryKirillov/activity-parser/zipball/5e7ad3baf6b7e766c0fb2c5eaf01f70a59b5de00",
+                "reference": "5e7ad3baf6b7e766c0fb2c5eaf01f70a59b5de00",
+                "shasum": ""
+            },
+            "require": {
+                "ext-libxml": "*",
+                "ext-simplexml": "*",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DmitryKirillov\\ActivityParser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dmitry Kirillov",
+                    "email": "esteps.kirillov@gmail.com"
+                }
+            ],
+            "description": "PHP parser for files created by fitness applications (TCX)",
+            "keywords": [
+                "fitness",
+                "parser",
+                "tcx",
+                "workout"
+            ],
+            "time": "2019-12-27T18:56:59+00:00"
+        },
+        {
+            "name": "dmitrykirillov/activity-parser-laravel",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DmitryKirillov/activity-parser-laravel.git",
+                "reference": "f9fc019b6fcd6898aa34c82c36b406d7b8d688f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DmitryKirillov/activity-parser-laravel/zipball/f9fc019b6fcd6898aa34c82c36b406d7b8d688f2",
+                "reference": "f9fc019b6fcd6898aa34c82c36b406d7b8d688f2",
+                "shasum": ""
+            },
+            "require": {
+                "dmitrykirillov/activity-parser": "dev-master",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "DmitryKirillov\\ActivityParserLaravel\\PackageServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DmitryKirillov\\ActivityParserLaravel\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dmitry Kirillov",
+                    "email": "esteps.kirillov@gmail.com"
+                }
+            ],
+            "description": "Laravel package for PHP parser for files created by fitness app",
+            "time": "2019-12-28T16:04:16+00:00"
+        },
         {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "0.1",
@@ -4899,7 +4993,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "dmitrykirillov/activity-parser-laravel": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/tests/Feature/Console/Commands/ParceTCXTest.php
+++ b/tests/Feature/Console/Commands/ParceTCXTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Feature\Console\Commands;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class ParceTCXTest extends TestCase
+{
+    /**
+     * Test if Artisan command exists.
+     */
+    public function testArtisanCommandExists()
+    {
+        $this->assertTrue(array_key_exists('activity:parse-tcx', Artisan::all()));
+    }
+}

--- a/tests/Feature/Console/Commands/ParseTCXTest.php
+++ b/tests/Feature/Console/Commands/ParseTCXTest.php
@@ -5,7 +5,7 @@ namespace Feature\Console\Commands;
 use Illuminate\Support\Facades\Artisan;
 use Tests\TestCase;
 
-class ParceTCXTest extends TestCase
+class ParseTCXTest extends TestCase
 {
     /**
      * Test if Artisan command exists.


### PR DESCRIPTION
Шаг 1. Я разработал библиотеку Activity Parser, которая парсит файлы из спортивных приложений и позволяет получить сводную информацию о пробежке + массив географических точек. Код сырой, в нём много todo, но он полностью рабочий. Покрытие тестами – 100%.

Текущий релиз – v0.0.1-alpha
GitHub – https://github.com/DmitryKirillov/activity-parser
Установка – composer require dmitrykirillov/activity-parser

Шаг 2. Для интеграции библиотеки и Laravel я разработал отдельный пакет, который регистрирует команду Artisan для обработки файлов из командной строки. Другие компоненты пакетов (роуты, миграции и т.д.) для моего приложения не нужны. Для тестов использовал библиотеку orchestra/testbench. Покрытие тестами – 100%.

Текущий релиз – v0.0.1-alpha
GitHub – https://github.com/DmitryKirillov/activity-parser-laravel
Установка – composer require dmitrykirillov/activity-parser-laravel

Шаг 3. В репозитории с проектом я подключил новый пакет и добавил ещё один тест для проверки регистрации команды Artisan. Здесь возникла проблема: пакет автоматически зарегистрировал команду в CLI (и она работает из командной строки), но в тестах (через $this->artisan) команда не была доступна. Проблему удалось решить только ручной регистрацией пакета в AppServiceProvider.