### PR TITLE
HW14: Очереди

### DIFF
--- a/app/Jobs/PhpInsightsJob.php
+++ b/app/Jobs/PhpInsightsJob.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Commit;
+use App\Services\PhpInsightsService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class PhpInsightsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * @var Commit
+     */
+    private $commit;
+    /**
+     * @var string
+     */
+    private $sourceDir;
+    /**
+     * @var int
+     */
+    private $projectId;
+
+    public function __construct(Commit $commit, string $sourceDir, int $projectId)
+    {
+        $this->commit = $commit;
+        $this->sourceDir = $sourceDir;
+        $this->projectId = $projectId;
+    }
+
+    public function handle(PhpInsightsService $phpInsightsService)
+    {
+        $phpInsightsService->exec($this->commit, $this->sourceDir, $this->projectId);
+    }
+}

--- a/app/Jobs/PhpLocJob.php
+++ b/app/Jobs/PhpLocJob.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Commit;
+use App\Services\PhpLocService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class PhpLocJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * @var Commit
+     */
+    private $commit;
+    /**
+     * @var string
+     */
+    private $sourceDir;
+    /**
+     * @var int
+     */
+    private $projectId;
+
+    public function __construct(Commit $commit, string $sourceDir, int $projectId)
+    {
+        $this->commit = $commit;
+        $this->sourceDir = $sourceDir;
+        $this->projectId = $projectId;
+    }
+
+    public function handle(PhpLocService $phpLocService)
+    {
+        $phpLocService->exec($this->commit, $this->sourceDir, $this->projectId);
+    }
+}

--- a/app/Jobs/ProjectHistoryJob.php
+++ b/app/Jobs/ProjectHistoryJob.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Helpers\UrlHelpers;
+use App\Models\Project;
+use App\Services\CommitService;
+use App\Services\GitOperations;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProjectHistoryJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    private const DEFAULT_DEPTH = 50;
+
+    /**
+     * @var Project
+     */
+    private $project;
+    /**
+     * @var int
+     */
+    private $depth;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Project $project, int $depth = self::DEFAULT_DEPTH)
+    {
+        $this->project = $project;
+        $this->depth = $depth;
+    }
+
+    public function handle(GitOperations $gitOperations, CommitService $commitService)
+    {
+        if (!UrlHelpers::isValidRepositoryUrl($this->project->url)) {
+            return;
+        }
+
+        $sourceDir = $gitOperations->clone($this->project->url, $this->depth);
+
+        foreach ($gitOperations->checkoutParentIterator($sourceDir, $this->depth) as $_) {
+
+            // Create or find Commit record based on Git Source Code and current Repository record
+            $commit = $commitService->storeCommitFromSource($sourceDir, $this->project->repository_id);
+
+            // Clone source tree into separate directory
+            $separateSourceDirForThisCommit = $gitOperations->clone($sourceDir);
+
+            // Run jobs for async analyze
+            PhpLocJob::dispatch($commit, $separateSourceDirForThisCommit, $this->project->id);
+            PhpInsightsJob::dispatch($commit, $separateSourceDirForThisCommit, $this->project->id);
+
+        }
+
+    }
+}

--- a/tests/Unit/Jobs/PhpInsightsJobTest.php
+++ b/tests/Unit/Jobs/PhpInsightsJobTest.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Tests\Unit\Jobs;
+
+
+use App\Jobs\PhpInsightsJob;
+use App\Models\Commit;
+use App\Services\PhpInsightsService;
+use Tests\TestCase;
+
+class PhpInsightsJobTest extends TestCase
+{
+    public function testHandle()
+    {
+        $commit = new Commit();
+        $sourceDir = 'dummy_dir';
+        $projectId = random_int(1, 100);
+
+        $phpInsightsService = \Mockery::mock(PhpInsightsService::class);
+        $phpInsightsService->shouldReceive('exec')->with($commit, $sourceDir, $projectId);
+
+        $job = new PhpInsightsJob($commit, $sourceDir, $projectId);
+        $job->handle($phpInsightsService);
+    }
+}

--- a/tests/Unit/Jobs/PhpLocJobTest.php
+++ b/tests/Unit/Jobs/PhpLocJobTest.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Tests\Unit\Jobs;
+
+
+use App\Jobs\PhpLocJob;
+use App\Models\Commit;
+use App\Services\PhpLocService;
+use Tests\TestCase;
+
+class PhpLocJobTest extends TestCase
+{
+    public function testHandle()
+    {
+        $commit = new Commit();
+        $sourceDir = 'dummy_dir';
+        $projectId = random_int(1, 100);
+
+        $phpLocService = \Mockery::mock(PhpLocService::class);
+        $phpLocService->shouldReceive('exec')->with($commit, $sourceDir, $projectId);
+
+        $job = new PhpLocJob($commit, $sourceDir, $projectId);
+        $job->handle($phpLocService);
+    }
+}

--- a/tests/Unit/Jobs/ProjectHistoryJobTest.php
+++ b/tests/Unit/Jobs/ProjectHistoryJobTest.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace Tests\Unit\Jobs;
+
+
+use App\Jobs\PhpInsightsJob;
+use App\Jobs\PhpLocJob;
+use App\Jobs\ProjectHistoryJob;
+use App\Models\Commit;
+use App\Services\CommitService;
+use App\Services\GitOperations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\Generators\ProjectGenerator;
+use Tests\TestCase;
+
+class ProjectHistoryJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testHandle()
+    {
+        Queue::fake();
+
+        $project = ProjectGenerator::createWithLocalGitRepo();
+        $gitOperations = resolve(GitOperations::class);
+        $commitService = resolve(CommitService::class);
+
+        $depth = 3;
+
+        $historyJob = new ProjectHistoryJob($project, $depth);
+        $historyJob->handle($gitOperations, $commitService);
+
+        // Assert that commits were stored in database
+        $this->assertGreaterThanOrEqual($depth, Commit::count());
+
+        // As a result new jobs to be dispatched for each commit (so $depth times)
+        Queue::assertPushed(PhpLocJob::class, $depth);
+        Queue::assertPushed(PhpInsightsJob::class, $depth);
+    }
+}


### PR DESCRIPTION
Работа над очередями.

Создал 3 Job:

PhpLocJob: запускает анализатор кода PHP LOC на указанном дереве исходников
PhpInsightsJob: запускает анализатор кода PHP Insights на указанном дереве исходников 

ProjectHistoryJob: самое интересное
1) клонирует git репозиторий проекта во временную директорию с глубиной истории 50 и затем из него создаёт ещё 50 клонов на каждый коммит: таким образом на жестком диске получается 50 временных директорий с источниками проекта на разные моменты времени. Клонирование по папкам осуществляется синхронно в цикле
2) На каждой итерации цикла происходит dispatch двух задач: PhpLocJob и PhpInsightsJob с указанием очередной директории (с очередным коммитом) - таким образом мы добавляем в очередь 100 задач (50 коммитов х 2 анализатора).

На production сервере планируется держать запущенными достаточное кол-во воркеров, чтобы максимально быстро исполнять поставленные задачи.

3) По окончании анализа очередного коммита нужно удалить соответствующую директорию с исходниками, но как это сделать пока не придумал - это нужно сделать после окончания двух параллельно выполняемых задач PhpLocJob и PhpInsightsJob.

Для всех трёх Job подготовлены тесты.

